### PR TITLE
Introduces initial version of the PoolParty Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 charts/
 values_overrides.yaml
 template_output.yaml
+output.yaml
 *.tgz
 
 # Sensitive files

--- a/graphwise-platform/Chart.lock
+++ b/graphwise-platform/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: graphdb
   repository: https://maven.ontotext.com/repository/helm-public/
   version: 12.1.1
-digest: sha256:dfd341a3902a5c64ef29cbbda34e7d4883765da400bbd5289606550ce2f5ec4e
-generated: "2025-09-29T16:21:53.552308967+03:00"
+- name: poolparty
+  repository: file://../poolparty
+  version: 0.1.0
+digest: sha256:fcec4606aa4692a68716f1d0d92ee8ac37b455a2eb618ccb0889d07fe3044125
+generated: "2025-10-09T09:20:38.138703563+03:00"

--- a/graphwise-platform/Chart.yaml
+++ b/graphwise-platform/Chart.yaml
@@ -14,3 +14,9 @@ dependencies:
     version: 12.1.1
     repository: https://maven.ontotext.com/repository/helm-public/
     condition: graphdb.enabled
+
+  # PoolParty
+  - name: poolparty
+    version: 0.1.0
+    repository: file://../poolparty
+    condition: poolparty.enabled

--- a/graphwise-platform/values.yaml
+++ b/graphwise-platform/values.yaml
@@ -8,3 +8,19 @@ graphdb:
   # Commercial license is required for using GraphDB version >= 11.
   license:
     existingSecret: ""
+
+#################################################################
+#                                                               #
+# PoolParty configuration overrides.                            #
+#                                                               #
+# For more information please visit: TODO                       #
+# Or refer to the Official Helm Chart in the current repository #
+#################################################################
+
+poolparty:
+  # Toggles the deployment of PoolParty.
+  enabled: true
+
+  license:
+    # The name of the Secret providing the license.
+    existingSecret: ""

--- a/poolparty/.helmignore
+++ b/poolparty/.helmignore
@@ -1,0 +1,39 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Custom
+*.license
+*.gpg
+*.pgp
+.github/
+examples/
+template_output.yaml
+output.yaml
+trivy.yaml
+values_*.yaml
+.helmignore
+*.md.gotmpl
+*.tgz
+.editorconfig
+.gitattributes

--- a/poolparty/CHANGELOG.md
+++ b/poolparty/CHANGELOG.md
@@ -1,0 +1,7 @@
+# PoolParty Helm Chart Changelog
+
+## Version 0.1.0
+
+### New
+
+- Added initial version of the PoolParty Helm Chart.

--- a/poolparty/Chart.yaml
+++ b/poolparty/Chart.yaml
@@ -1,0 +1,22 @@
+#
+# Official Helm chart for PoolParty.
+#
+apiVersion: v2
+name: poolparty
+description: PoolParty is a semantic middleware, it tackles the ever-growing problems associated with unstructured data, language ambiguity, and data silos.
+type: application
+version: 0.1.0
+appVersion: 10.0.0
+kubeVersion: ^1.26.0-0
+home: https://www.poolparty.biz/
+icon: https://www.poolparty.biz/wp-content/uploads/2017/04/pp_logo.svg
+maintainers:
+  - name: Graphwise
+    email: dnd@graphwise.ai
+sources:
+  - https://github.com/poolparty-semantic-suite/charts
+keywords:
+  - graphwise
+  - poolparty
+  - graphdb
+  - semantic

--- a/poolparty/LICENSE
+++ b/poolparty/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/poolparty/README.md
+++ b/poolparty/README.md
@@ -1,0 +1,419 @@
+# Helm Chart for PoolParty
+
+<!-- [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml) -->
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![AppVersion: 10.0.0](https://img.shields.io/badge/AppVersion-10.0.0-informational?style=flat-square)
+
+<!--
+TODO: Add ArtifactHub badge when ready
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/ontotext)](https://artifacthub.io/packages/helm/ontotext/graphdb)
+-->
+
+Welcome to the official [Helm](https://helm.sh/) chart repository for [PoolParty](https://www.poolparty.biz/)!
+This Helm chart makes it easy to deploy and manage PoolParty on your [Kubernetes](https://kubernetes.io/) cluster.
+
+## Quickstart
+
+```shell
+helm repo add graphwize https://maven.ontotext.com/repository/helm-public/
+helm install poolparty graphwize/poolparty #TODO
+```
+
+## About PoolParty
+
+<p align="center">
+  <a href="https://www.poolparty.biz/">
+    <picture>
+      <img src="https://www.poolparty.biz/wp-content/uploads/2017/04/pp_logo.svg" alt="PoolParty logo" title="PoolParty">
+    </picture>
+  </a>
+</p>
+
+The PoolParty Semantic Suite is a comprehensive middleware software. It includes browser-based taxonomy management,
+thesaurus management, linked data frontend, ontology management, corpus management, extractor and a semantic middleware configurator.
+
+<!--
+TODO: Info about the basic Helm chart features ?
+## Features
+-->
+
+## Prerequisites
+
+* Kubernetes v1.26+
+* Helm v3.8+
+
+### Getting Started
+
+If this is your first time installing a Helm chart, you should read the following introductions before continuing:
+
+- Docker https://docs.docker.com/get-started/
+- Kubernetes concepts https://kubernetes.io/docs/concepts/
+- Helm https://helm.sh/docs/intro/quickstart/
+
+After getting familiar with the above, you need to install the following binaries on your machine:
+
+- Install Helm 3: https://helm.sh/docs/intro/install/
+- Install `kubectl`: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+
+Next, you would need access to a Kubernetes cluster. You can set up a local one or use one of the cloud providers, e.g.:
+
+* Minikube https://minikube.sigs.k8s.io/docs/
+* kind https://kind.sigs.k8s.io/
+* Amazon EKS https://aws.amazon.com/eks/
+* Azure AKS https://azure.microsoft.com/en-us/products/kubernetes-service
+* Google GKE https://cloud.google.com/kubernetes-engine
+
+### PoolParty License
+
+To use PoolParty, you need a license.
+If you have a PoolParty license, create a Secret object with a `poolparty.key` data entry:
+
+```shell
+kubectl create secret generic poolparty-license --from-file poolparty.key=poolparty.key
+```
+
+Then add the secret name to the values.yaml file under the `license.existingSecret` configuration.
+
+**Note**: Secret names can differ from the given examples in the [values.yaml](values.yaml), but their configurations
+should be updated to refer to the correct ones. Note that the licenses can be set for all node instances. Please setup
+correctly according to the licensing agreements.
+
+## Install
+
+### Version Compatibility
+
+The next table highlights the version mapping between the Helm chart and the deployed PoolParty.
+
+| Helm chart version | PoolParty version |
+|--------------------|-------------------|
+| 0.1.x              | 10.x.x            |
+
+### Install from Repository
+
+TODO: we need to decide what will be used as charts registry - GitHub or Ontotext Nexus
+      Is it going to stay `ontotext` or are we going with `graphwise`? There are several places that must be updated, if it is `graphwise`.
+
+1. Add PoolParty repository
+
+    ```shell
+    helm repo add ontotext https://maven.ontotext.com/repository/helm-public/
+    ```
+
+2. Install PoolParty
+
+    ```shell
+    helm install poolparty ontotext/poolparty
+    ```
+
+3. Upgrade PoolParty deployment
+
+   ```shell
+   helm upgrade --install poolparty ontotext/poolparty
+   ```
+
+See [Configuration](#configuration) and [values.yaml](values.yaml) on how to customize your PoolParty deployment.
+
+### Provenance
+
+TODO: double-check this one
+
+Helm can verify the origin and integrity of the Helm chart by:
+
+1. Importing the public GnuPG key for PoolParty Helm:
+
+    ```shell
+    gpg --keyserver keyserver.ubuntu.com --recv-keys 8E1B45AF8157DB82
+    # Helm uses the legacy gpg format
+    gpg --export > ~/.gnupg/pubring.gpg
+    ```
+
+2. Running `helm install` with the `--verify` flag, i.e.:
+
+    ```shell
+    helm install --verify poolparty ontotext/poolparty
+    ```
+
+**Note**: The verification works only when installing from a local tar.gz or when installing from the repository.
+
+Check the official documentation for more information https://helm.sh/docs/topics/provenance/
+
+### Uninstall
+
+To remove the deployed PoolParty, use:
+
+```shell
+helm uninstall poolparty
+```
+
+**Note**: It is important to note that this will not remove any data, so the next time it is installed, the data will be
+          loaded by its components.
+
+## Upgrading
+
+The Helm chart follows [Semantic Versioning v2](https://semver.org/) so any breaking changes will be rolled out only in
+MAJOR versions of the chart.
+
+Please, always check out the migration guides in [UPGRADE.md](UPGRADE.md), before switching to another major version of
+the Helm chart.
+
+## Configuration
+
+Every component and resource is configured with sensible defaults in [values.yaml](values.yaml).
+Make sure you read it thoroughly, understand each property and the impact of changing any one of them.
+
+Helm allows you to override values from [values.yaml](values.yaml) in several ways.
+See https://helm.sh/docs/chart_template_guide/values_files/.
+
+* Using a separate values.yaml with overrides:
+
+  ```shell
+  helm install poolparty ontotext/poolparty -f overrides.yaml
+  ```
+
+* Overriding specific values:
+
+  ```shell
+  helm install poolparty ontotext/poolparty --set security.enabled=true
+  ```
+
+### Provisioning Additional Properties and Settings
+
+TODO: extend when we finalize the configurations settings and how they will be provisioned
+
+Most of PoolParty's properties can be passed through `configuration.properties` or `configuration.javaArguments`.
+The `configuration` section holds subsections for some of the specific and external components, required by PoolParty.
+
+PoolParty uses Logback to configure logging using the `logback.xml` file.
+The file can be provisioned before PoolParty's startup with the `configuration.logback.existingConfigmap` configuration.
+
+See TODO reference
+
+See TODO reference
+
+### Networking
+
+By default, PoolParty's Helm chart comes with a default Ingress.
+The Ingress can be disabled by switching `ingress.enabled` to false.
+
+### Cloud Deployments Specifics
+
+Some cloud Kubernetes clusters have some specifics that should be noted. Here are some useful tips on some cloud K8s
+clusters:
+
+##### Microsoft Azure
+
+We recommend not to use the Microsoft Azure storage of type `azurefile`. The write speeds of this storage type when used
+in a Kubernetes cluster is not good enough for PoolParty, and we recommend against using it in production environments.
+
+See https://github.com/Azure/AKS/issues/223
+
+### Deployment
+
+Some important properties to update according to your deployment are:
+
+* `configuration.externalUrl` - Configures the address at which the Ingress controller and PoolParty are accessible.
+
+### Resources
+
+Each component is defined with default resource limits that are sufficient to deploy the chart and use it with small
+sets of data. However, for production deployments it is obligatory to revise these resource limits and tune them for
+your environment. You should consider common requirements like amount of data, users, expected traffic.
+
+Look for `<component>.resources` blocks in [values.yaml](values.yaml). During Helm's template rendering, these YAML
+blocks are inserted in the Kubernetes pod configurations as pod resource limits. Most resource configuration blocks are
+referring to official documentations.
+
+See the Kubernetes documentation
+[Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
+about defining resource limits.
+
+## Examples
+
+Checkout the [examples/](examples) folder in this repository.
+
+## Values
+
+<!--
+IMPORTANT: This is generated by helm-docs, do not attempt modifying it on hand as it will be automatically generated.
+-->
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
+| args | list | `[]` |  |
+| automountServiceAccountToken | bool | `false` |  |
+| command | list | `[]` |  |
+| configuration.defaultJavaArguments | string | `"-XX:MaxRAMPercentage=85"` |  |
+| configuration.externalUrl | string | `"http://poolparty.127.0.0.1.nip.io"` |  |
+| configuration.javaArguments | string | `""` |  |
+| configuration.logback.configmapKey | string | `"logback.xml"` |  |
+| configuration.logback.existingConfigmap | string | `""` |  |
+| configuration.properties.POOLPARTY_GRAPHDB_PASSWORD | string | `"root"` |  |
+| configuration.properties.POOLPARTY_GRAPHDB_URL | string | `"http://graphdb:7200"` |  |
+| configuration.properties.POOLPARTY_GRAPHDB_USERNAME | string | `"admin"` |  |
+| configuration.properties.POOLPARTY_INDEX_TYPE | string | `"elasticsearch"` |  |
+| configuration.properties.POOLPARTY_INDEX_URL | string | `"http://elasticsearch:9200"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_ADMIN_CLIENTID | string | `"admin-cli"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_ADMIN_CLIENTSECRET | string | `"nPFFgUeLbmzjd28IObJEkkMtvd4TzvdF"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_ADMIN_PASSWORD | string | `"admin"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_ADMIN_REALM | string | `"master"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_ADMIN_USERNAME | string | `"poolparty_auth_admin"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_AUTHURL | string | `"http://keycloak:8080/auth"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_LOGIN_CLIENTID | string | `"ppt"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_LOGIN_CLIENTSECRET | string | `"yaOd67b2HdQ28hmvuWvZMpn3TLrmhZ1u"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_LOGIN_ENABLEBASICAUTH | bool | `true` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_LOGIN_PRINCIPALATTRIBUTE | string | `"preferred_username"` |  |
+| configuration.properties.POOLPARTY_KEYCLOAK_LOGIN_REALM | string | `"poolparty"` |  |
+| configuration.properties._POOLPARTY_ENCRYPTION_PASSWORD | string | `"6wFdqOjvxuyeDvh1ENTm"` |  |
+| configuration.propertiesOverrides.existingConfigmap | string | `""` |  |
+| configuration.propertiesOverrides.existingSecret | string | `""` |  |
+| containerPorts.http | int | `8081` |  |
+| dnsConfig | object | `{}` |  |
+| dnsPolicy | string | `""` |  |
+| extraContainerPorts | object | `{}` |  |
+| extraContainers | list | `[]` |  |
+| extraEnv | list | `[]` |  |
+| extraEnvFrom | list | `[]` |  |
+| extraInitContainers | list | `[]` |  |
+| extraObjects | list | `[]` |  |
+| extraVolumeClaimTemplates | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.clusterDomain | string | `"cluster.local"` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"ontotext/poolparty"` |  |
+| image.tag | string | `""` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `true` |  |
+| ingress.extraHosts | list | `[]` |  |
+| ingress.extraTLS | list | `[]` |  |
+| ingress.host | string | `""` |  |
+| ingress.labels | object | `{}` |  |
+| ingress.path | string | `""` |  |
+| ingress.pathType | string | `"Prefix"` |  |
+| ingress.tls.enabled | bool | `false` |  |
+| ingress.tls.secretName | string | `""` |  |
+| initContainerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| initContainerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| initContainerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| initContainerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| labels | object | `{}` |  |
+| license.existingSecret | string | `""` |  |
+| license.licenseFilename | string | `"poolparty.key"` |  |
+| license.optional | bool | `false` |  |
+| license.readOnly | bool | `true` |  |
+| livenessProbe.httpGet.path | string | `"/PoolParty/health/liveness"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.initialDelaySeconds | int | `60` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.emptyDir.sizeLimit | string | `"1Gi"` |  |
+| persistence.enabled | bool | `true` |  |
+| persistence.volumeClaimRetentionPolicy | object | `{}` |  |
+| persistence.volumeClaimTemplate.annotations | object | `{}` |  |
+| persistence.volumeClaimTemplate.labels | object | `{}` |  |
+| persistence.volumeClaimTemplate.name | string | `"storage"` |  |
+| persistence.volumeClaimTemplate.spec.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistence.volumeClaimTemplate.spec.resources.requests.storage | string | `"5Gi"` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinity.enabled | bool | `true` |  |
+| podAntiAffinity.preset | string | `"soft"` |  |
+| podAntiAffinity.topology | string | `"kubernetes.io/hostname"` |  |
+| podLabels | object | `{}` |  |
+| podManagementPolicy | string | `"Parallel"` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
+| podSecurityContext.runAsGroup | int | `1001` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.runAsUser | int | `1001` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.httpGet.path | string | `"/PoolParty/health/readiness"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.timeoutSeconds | int | `5` |  |
+| resources.limits.memory | string | `"8Gi"` |  |
+| resources.requests.cpu | string | `"500m"` |  |
+| resources.requests.memory | string | `"8Gi"` |  |
+| revisionHistoryLimit | int | `10` |  |
+| schedulerName | string | `""` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| service.annotations | object | `{}` |  |
+| service.enabled | bool | `true` |  |
+| service.externalIPs | list | `[]` |  |
+| service.externalTrafficPolicy | string | `""` |  |
+| service.extraPorts | list | `[]` |  |
+| service.healthCheckNodePort | string | `""` |  |
+| service.labels | object | `{}` |  |
+| service.loadBalancerClass | string | `""` |  |
+| service.loadBalancerSourceRanges | list | `[]` |  |
+| service.nodePort | string | `""` |  |
+| service.ports.http | int | `8081` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| startupProbe.failureThreshold | int | `300` |  |
+| startupProbe.httpGet.path | string | `"/PoolParty/health/startup"` |  |
+| startupProbe.httpGet.port | string | `"http"` |  |
+| startupProbe.periodSeconds | int | `3` |  |
+| startupProbe.timeoutSeconds | int | `1` |  |
+| tempVolume.emptyDir.sizeLimit | string | `"128Mi"` |  |
+| tempVolume.enabled | bool | `true` |  |
+| terminationGracePeriodSeconds | int | `120` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+
+## Troubleshooting
+
+**Helm install hangs**
+
+If there is no output after `helm install`, it is likely that a hook cannot execute.
+Check their logs with `kubectl logs`.
+
+Another reason could be that the default timeout of 5 minutes for Helm `install` or `upgrade` is not enough.
+You can increase the timeout by adding `--timeout 10m` (or more) to the Helm command.
+
+**Connection issues**
+
+If connections time out or the pods cannot resolve each other, it is likely that the Kubernetes DNS is broken. This is a
+common issue with Minikube between system restarts or when inappropriate Minikube driver is used. Please refer to
+[Debugging DNS Resolution](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/).
+
+**Filesystem provisioning errors (in Multi-Node Minikube Cluster)**
+
+When expanding your Minikube cluster from one to two or more nodes to deploy different PoolParty instances across
+multiple nodes to ensure high availability, you may encounter errors when setting up persistent storage. These issues
+are due to implementation problems with the storage provisioner included with Minikube. To resolve this, you need to
+adjust your environment accordingly. Follow the steps outlined in the official Minikube documentation under the
+["CSI Driver and Volume Snapshots"](https://minikube.sigs.k8s.io/docs/tutorials/volume_snapshots_and_csi/) section,
+specifically in the "Multi-Node Clusters" chapter.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Graphwise | <dnd@graphwise.ai> |  |
+
+## Contributing
+
+If you have any suggestions, bug reports, or feature requests, please open an issue or submit a pull request.
+
+## License
+
+This code is released under the Apache 2.0 License. See [LICENSE](LICENSE) for more details.

--- a/poolparty/README.md.gotmpl
+++ b/poolparty/README.md.gotmpl
@@ -1,0 +1,278 @@
+# Helm Chart for PoolParty
+
+<!-- [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml) -->
+{{ template "chart.versionBadge" . }}
+{{ template "chart.appVersionBadge" . }}
+
+<!--
+TODO: Add ArtifactHub badge when ready
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/ontotext)](https://artifacthub.io/packages/helm/ontotext/graphdb)
+-->
+
+Welcome to the official [Helm](https://helm.sh/) chart repository for [PoolParty](https://www.poolparty.biz/)!
+This Helm chart makes it easy to deploy and manage PoolParty on your [Kubernetes](https://kubernetes.io/) cluster.
+
+## Quickstart
+
+```shell
+helm repo add graphwize https://maven.ontotext.com/repository/helm-public/
+helm install poolparty graphwize/poolparty #TODO
+```
+
+## About PoolParty
+
+<p align="center">
+  <a href="https://www.poolparty.biz/">
+    <picture>
+      <img src="https://www.poolparty.biz/wp-content/uploads/2017/04/pp_logo.svg" alt="PoolParty logo" title="PoolParty">
+    </picture>
+  </a>
+</p>
+
+The PoolParty Semantic Suite is a comprehensive middleware software. It includes browser-based taxonomy management,
+thesaurus management, linked data frontend, ontology management, corpus management, extractor and a semantic middleware configurator.
+
+<!--
+TODO: Info about the basic Helm chart features ?
+## Features
+-->
+
+## Prerequisites
+
+* Kubernetes v1.26+
+* Helm v3.8+
+
+### Getting Started
+
+If this is your first time installing a Helm chart, you should read the following introductions before continuing:
+
+- Docker https://docs.docker.com/get-started/
+- Kubernetes concepts https://kubernetes.io/docs/concepts/
+- Helm https://helm.sh/docs/intro/quickstart/
+
+After getting familiar with the above, you need to install the following binaries on your machine:
+
+- Install Helm 3: https://helm.sh/docs/intro/install/
+- Install `kubectl`: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+
+Next, you would need access to a Kubernetes cluster. You can set up a local one or use one of the cloud providers, e.g.:
+
+* Minikube https://minikube.sigs.k8s.io/docs/
+* kind https://kind.sigs.k8s.io/
+* Amazon EKS https://aws.amazon.com/eks/
+* Azure AKS https://azure.microsoft.com/en-us/products/kubernetes-service
+* Google GKE https://cloud.google.com/kubernetes-engine
+
+### PoolParty License
+
+To use PoolParty, you need a license.
+If you have a PoolParty license, create a Secret object with a `poolparty.key` data entry:
+
+```shell
+kubectl create secret generic poolparty-license --from-file poolparty.key=poolparty.key
+```
+
+Then add the secret name to the values.yaml file under the `license.existingSecret` configuration.
+
+**Note**: Secret names can differ from the given examples in the [values.yaml](values.yaml), but their configurations
+should be updated to refer to the correct ones. Note that the licenses can be set for all node instances. Please setup
+correctly according to the licensing agreements.
+
+## Install
+
+### Version Compatibility
+
+The next table highlights the version mapping between the Helm chart and the deployed PoolParty.
+
+| Helm chart version | PoolParty version |
+|--------------------|-------------------|
+| 0.1.x              | 10.x.x            |
+
+
+### Install from Repository
+
+TODO: we need to decide what will be used as charts registry - GitHub or Ontotext Nexus
+      Is it going to stay `ontotext` or are we going with `graphwise`? There are several places that must be updated, if it is `graphwise`.
+
+1. Add PoolParty repository
+
+    ```shell
+    helm repo add ontotext https://maven.ontotext.com/repository/helm-public/
+    ```
+
+2. Install PoolParty
+
+    ```shell
+    helm install poolparty ontotext/poolparty
+    ```
+
+3. Upgrade PoolParty deployment
+
+   ```shell
+   helm upgrade --install poolparty ontotext/poolparty
+   ```
+
+See [Configuration](#configuration) and [values.yaml](values.yaml) on how to customize your PoolParty deployment.
+
+### Provenance
+
+TODO: double-check this one
+
+Helm can verify the origin and integrity of the Helm chart by:
+
+1. Importing the public GnuPG key for PoolParty Helm:
+
+    ```shell
+    gpg --keyserver keyserver.ubuntu.com --recv-keys 8E1B45AF8157DB82
+    # Helm uses the legacy gpg format
+    gpg --export > ~/.gnupg/pubring.gpg
+    ```
+
+2. Running `helm install` with the `--verify` flag, i.e.:
+
+    ```shell
+    helm install --verify poolparty ontotext/poolparty
+    ```
+
+**Note**: The verification works only when installing from a local tar.gz or when installing from the repository.
+
+Check the official documentation for more information https://helm.sh/docs/topics/provenance/
+
+### Uninstall
+
+To remove the deployed PoolParty, use:
+
+```shell
+helm uninstall poolparty
+```
+
+**Note**: It is important to note that this will not remove any data, so the next time it is installed, the data will be
+          loaded by its components.
+
+## Upgrading
+
+The Helm chart follows [Semantic Versioning v2](https://semver.org/) so any breaking changes will be rolled out only in
+MAJOR versions of the chart.
+
+Please, always check out the migration guides in [UPGRADE.md](UPGRADE.md), before switching to another major version of
+the Helm chart.
+
+## Configuration
+
+Every component and resource is configured with sensible defaults in [values.yaml](values.yaml).
+Make sure you read it thoroughly, understand each property and the impact of changing any one of them.
+
+Helm allows you to override values from [values.yaml](values.yaml) in several ways.
+See https://helm.sh/docs/chart_template_guide/values_files/.
+
+* Using a separate values.yaml with overrides:
+
+  ```shell
+  helm install poolparty ontotext/poolparty -f overrides.yaml
+  ```
+
+* Overriding specific values:
+
+  ```shell
+  helm install poolparty ontotext/poolparty --set security.enabled=true
+  ```
+
+### Provisioning Additional Properties and Settings
+
+TODO: extend when we finalize the configurations settings and how they will be provisioned
+
+Most of PoolParty's properties can be passed through `configuration.properties` or `configuration.javaArguments`.
+The `configuration` section holds subsections for some of the specific and external components, required by PoolParty.
+
+PoolParty uses Logback to configure logging using the `logback.xml` file.
+The file can be provisioned before PoolParty's startup with the `configuration.logback.existingConfigmap` configuration.
+
+See TODO reference
+
+See TODO reference
+
+### Networking
+
+By default, PoolParty's Helm chart comes with a default Ingress.
+The Ingress can be disabled by switching `ingress.enabled` to false.
+
+### Cloud Deployments Specifics
+
+Some cloud Kubernetes clusters have some specifics that should be noted. Here are some useful tips on some cloud K8s
+clusters:
+
+##### Microsoft Azure
+
+We recommend not to use the Microsoft Azure storage of type `azurefile`. The write speeds of this storage type when used
+in a Kubernetes cluster is not good enough for PoolParty, and we recommend against using it in production environments.
+
+See https://github.com/Azure/AKS/issues/223
+
+### Deployment
+
+Some important properties to update according to your deployment are:
+
+* `configuration.externalUrl` - Configures the address at which the Ingress controller and PoolParty are accessible.
+
+### Resources
+
+Each component is defined with default resource limits that are sufficient to deploy the chart and use it with small
+sets of data. However, for production deployments it is obligatory to revise these resource limits and tune them for
+your environment. You should consider common requirements like amount of data, users, expected traffic.
+
+Look for `<component>.resources` blocks in [values.yaml](values.yaml). During Helm's template rendering, these YAML
+blocks are inserted in the Kubernetes pod configurations as pod resource limits. Most resource configuration blocks are
+referring to official documentations.
+
+See the Kubernetes documentation
+[Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
+about defining resource limits.
+
+## Examples
+
+Checkout the [examples/](examples) folder in this repository.
+
+## Values
+
+<!--
+IMPORTANT: This is generated by helm-docs, do not attempt modifying it on hand as it will be automatically generated.
+-->
+
+{{ template "chart.valuesTable" . }}
+
+## Troubleshooting
+
+**Helm install hangs**
+
+If there is no output after `helm install`, it is likely that a hook cannot execute.
+Check their logs with `kubectl logs`.
+
+Another reason could be that the default timeout of 5 minutes for Helm `install` or `upgrade` is not enough.
+You can increase the timeout by adding `--timeout 10m` (or more) to the Helm command.
+
+**Connection issues**
+
+If connections time out or the pods cannot resolve each other, it is likely that the Kubernetes DNS is broken. This is a
+common issue with Minikube between system restarts or when inappropriate Minikube driver is used. Please refer to
+[Debugging DNS Resolution](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/).
+
+**Filesystem provisioning errors (in Multi-Node Minikube Cluster)**
+
+When expanding your Minikube cluster from one to two or more nodes to deploy different PoolParty instances across
+multiple nodes to ensure high availability, you may encounter errors when setting up persistent storage. These issues
+are due to implementation problems with the storage provisioner included with Minikube. To resolve this, you need to
+adjust your environment accordingly. Follow the steps outlined in the official Minikube documentation under the
+["CSI Driver and Volume Snapshots"](https://minikube.sigs.k8s.io/docs/tutorials/volume_snapshots_and_csi/) section,
+specifically in the "Multi-Node Clusters" chapter.
+
+## Maintainers
+
+{{ template "chart.maintainersTable" . }}
+
+## Contributing
+
+If you have any suggestions, bug reports, or feature requests, please open an issue or submit a pull request.
+
+## License
+
+This code is released under the Apache 2.0 License. See [LICENSE](LICENSE) for more details.

--- a/poolparty/UPGRADE.md
+++ b/poolparty/UPGRADE.md
@@ -1,0 +1,3 @@
+# Migration Guide
+
+There are no migration notes at the moment.

--- a/poolparty/examples/properties-and-secrets/README.md
+++ b/poolparty/examples/properties-and-secrets/README.md
@@ -1,0 +1,100 @@
+# Configuring PoolParty
+
+This document provides detailed instructions on how to configure PoolParty, including setting properties, secret
+properties and additional configurations.
+
+It covers various methods to manage configuration options, such as using ConfigMaps and Secrets, and highlights some
+good practices to ensure secure and efficient setup. Additionally, it explains how to set Java arguments and environment
+variables for PoolParty.
+
+All PoolParty configuration options can be found TODO docs reference.
+
+## Properties
+
+This section is used to set PoolParty properties in the default ConfigMap directly from the `values.yaml` file.
+The configurations, typically including non-sensitive information such as product settings, external components
+addresses and so on.
+The default ConfigMap is used as source for environment variables, if it isn't overridden.
+
+```yaml
+configuration:
+  properties:
+    POOLPARTY_GRAPHDB_URL: "https://graphdb.custom-domain.com/"
+    POOLPARTY_KEYCLOAK_AUTHURL: "https://keycloak.custom-domain.com/auth"
+    POOLPARTY_INDEX_URL: "https://elastic.custom-domain.com/"
+```
+
+## Properties Overrides
+
+This section explains how to configure properties for PoolParty using an existing Kubernetes ConfigMap or an existing
+Secret. The resources mentioned in this section can be found in the [resources.yaml](./resources.yaml) file.
+
+The appropriate resources are used for each specific case.
+
+### Using Existing ConfigMap
+
+```yaml
+configuration:
+  propertiesOverrides:
+    existingConfigmap: custom-poolparty-properties
+```
+
+### Using Existing Secret
+
+```yaml
+configuration:
+  propertiesOverrides:
+    existingSecret: custom-poolparty-secret-properties
+```
+
+## Java Arguments
+
+This section explains how to set Java arguments for PoolParty using the `values.yaml` file. The
+`configuration.javaArguments` field allows you to specify Java Virtual Machine (JVM) options, such as memory settings,
+to optimize the performance and resource usage of the PoolParty instance.
+
+It also supports PoolParty properties in the form of `-Dproperty=value`.
+
+```yaml
+configuration:
+  javaArguments: "-Xms4G -Xmx4G -Dpoolparty.server.port=8081"
+```
+
+## Extra Environment Variables from a Source
+
+This section explains how to configure PoolParty with environment variables using an existing Kubernetes ConfigMap or an
+existing Secrets. This approach ensures that additional configurations are injected alongside existing or default ones
+without mixing different contexts.
+
+The resources referenced in this section can be found in the [resources.yaml](./resources.yaml) file.
+
+```yaml
+configuration:
+  properties:
+    ENCRYPTION_KEYSTRENGTH: 512
+    POOLPARTY_APPS: "thesaurus, graphsearch, extractor"
+
+extraEnvFrom:
+  - configMapRef:
+      name: custom-poolparty-properties
+  - secretRef:
+      name: custom-poolparty-secret-properties
+```
+
+## Extra Environment Variables
+
+This section demonstrates how environment variables can be directly set up in the Helm chart's `values.yaml` file,
+eliminating the need to configure them separately in a ConfigMap or Secret.
+
+```yaml
+extraEnv:
+  - name: "POOLPARTY_GRAPHDB_URL"
+    value: "https://graphdb.custom-domain.com"
+```
+
+## Final words
+
+The most recommended way of configuration PoolParty is by using existing resources, especially for the sensitive
+information. In this cases `configuration.propertiesOverrides` and `extraEnvFrom` are most suitable for this.
+
+For non-sensitive information any method of configuring PoolParty is viable.

--- a/poolparty/examples/properties-and-secrets/resources.yaml
+++ b/poolparty/examples/properties-and-secrets/resources.yaml
@@ -1,0 +1,28 @@
+# This YAML defines a ConfigMap and a Secret objects for a Kubernetes cluster.
+# - ConfigMap "custom-poolparty-properties" stores non-sensitive properties, which will be passed to the PoolParty as
+#   environment variables.
+# - Secret "custom-poolparty-secret-properties" stores a sensitive properties, which have to be encoded. They are also
+#   passed to the PoolParty as environment variables.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-poolparty-properties
+data:
+  POOLPARTY_GRAPHDB_URL: "https://graphdb.custom-domain.com/"
+  POOLPARTY_KEYCLOAK_AUTHURL: "https://keycloak.custom-domain.com/auth"
+  POOLPARTY_INDEX_TYPE: "elasticsearch"
+  POOLPARTY_INDEX_URL: "https://elastic.custom-domain.com/"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-poolparty-secret-properties
+data:
+  POOLPARTY_GRAPHDB_USERNAME: <base64-encoded secret>
+  POOLPARTY_GRAPHDB_PASSWORD: <base64-encoded secret>
+  POOLPARTY_KEYCLOAK_ADMIN_USERNAME: <base64-encoded secret>
+  POOLPARTY_KEYCLOAK_ADMIN_PASSWORD: <base64-encoded secret>
+  POOLPARTY_KEYCLOAK_ADMIN_CLIENTID: <base64-encoded secret>
+  POOLPARTY_KEYCLOAK_ADMIN_CLIENTSECRET: <base64-encoded secret>

--- a/poolparty/examples/properties-and-secrets/values.yaml
+++ b/poolparty/examples/properties-and-secrets/values.yaml
@@ -1,0 +1,8 @@
+# Overrides the default ConfigMap with the custom ConfigMap and Serret.
+# Note that you need to provide all of the required configuration properties in the new objects!
+configuration:
+  propertiesOverrides:
+    # The name of the predefined ConfigMap object, which is used as environment variables source.
+    existingConfigmap: custom-poolparty-properties
+    # The name of the predefined Secret object, which is used as additional environment variables source.
+    existingSecret: custom-poolparty-secret-properties

--- a/poolparty/templates/NOTES.txt
+++ b/poolparty/templates/NOTES.txt
@@ -1,0 +1,21 @@
+----------------------------------------------------------------------------------------------------
+.______     ______     ______    __      .______      ___      .______     .___________.____    ____
+|   _  \   /  __  \   /  __  \  |  |     |   _  \    /   \     |   _  \    |           |\   \  /   /
+|  |_)  | |  |  |  | |  |  |  | |  |     |  |_)  |  /  ^  \    |  |_)  |   `---|  |----` \   \/   /
+|   ___/  |  |  |  | |  |  |  | |  |     |   ___/  /  /_\  \   |      /        |  |       \_    _/
+|  |      |  `--'  | |  `--'  | |  `----.|  |     /  _____  \  |  |\  \----.   |  |         |  |
+| _|       \______/   \______/  |_______|| _|    /__/     \__\ | _| `._____|   |__|         |__|
+----------------------------------------------------------------------------------------------------
+
+Chart version: {{ .Chart.Version }}
+PoolParty version: {{ coalesce .Values.image.tag .Chart.AppVersion }}
+PoolParty URL: {{ include "poolparty.external-url" . }}
+
+** Please be patient while the chart is being deployed and services are available **
+You can check their status with kubectl --namespace {{ include "poolparty.namespace" . }} get pods
+
+{{- include "poolparty.notes.warnings" . }}
+
+----------------------------------------------------------------------------------------------------
+For more information on running PoolParty, visit https://help.poolparty.biz/
+----------------------------------------------------------------------------------------------------

--- a/poolparty/templates/_helpers.tpl
+++ b/poolparty/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Combined image pull secrets.
+*/}}
+{{- define "poolparty.combinedImagePullSecrets" -}}
+  {{- $secrets := concat .Values.global.imagePullSecrets .Values.image.pullSecrets }}
+  {{- tpl (toYaml $secrets) . -}}
+{{- end -}}
+
+{{/*
+Renders the container image for PoolParty.
+*/}}
+{{- define "poolparty.image" -}}
+  {{- $repository := .Values.image.repository -}}
+  {{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
+  {{- $image := printf "%s:%s" $repository $tag -}}
+  {{/* Add registry if present */}}
+  {{- $registry := .Values.global.imageRegistry | default .Values.image.registry -}}
+  {{- if $registry -}}
+    {{- $image = printf "%s/%s" $registry $image -}}
+  {{- end -}}
+  {{/* Add SHA digest if provided */}}
+  {{- if .Values.image.digest -}}
+    {{- $image = printf "%s@%s" $image .Values.image.digest -}}
+  {{- end -}}
+  {{- $image -}}
+{{- end -}}
+
+{{/*
+Renders the external PoolParty URL.
+*/}}
+{{- define "poolparty.external-url" -}}
+{{- tpl .Values.configuration.externalUrl . -}}
+{{- end -}}
+
+{{/*
+Checks for potential issues and prints warning messages.
+*/}}
+{{- define "poolparty.notes.warnings" -}}
+  {{- $warnings := list -}}
+  {{- if not .Values.persistence.enabled -}}
+    {{- $warnings = append $warnings "WARNING: Persistence is disabled! You will lose your data when PoolParty pods are restarted or terminated!" -}}
+  {{- end -}}
+  {{- if not .Values.license.existingSecret -}}
+    {{- $warnings = append $warnings "WARNING: You are deploying PoolParty without a license! You should obtain one before trying again." -}}
+  {{- end -}}
+  {{- if gt (len $warnings) 0 }}
+    {{- print "\n" }}
+    {{- range $warning, $index := $warnings }}
+{{ print $index }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/poolparty/templates/_labels.tpl
+++ b/poolparty/templates/_labels.tpl
@@ -1,0 +1,87 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "poolparty.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "poolparty.fullname" -}}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "poolparty.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "poolparty.labels" -}}
+helm.sh/chart: {{ include "poolparty.chart" . }}
+{{ include "poolparty.selectorLabels" . }}
+app.kubernetes.io/version: {{ coalesce .Values.image.tag .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: poolparty
+app.kubernetes.io/part-of: poolparty
+{{- if .Values.labels }}
+{{ tpl (toYaml .Values.labels) . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "poolparty.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "poolparty.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "poolparty.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create }}
+    {{- default (include "poolparty.fullname" .) .Values.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Returns the namespace of the release.
+*/}}
+{{- define "poolparty.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Creates a name for the ConfigMap with the PoolParty Java arguments.
+*/}}
+{{- define "poolparty.fullname.configmap.environment" -}}
+  {{- printf "%s-%s" (include "poolparty.fullname" .) "environment" -}}
+{{- end -}}
+
+{{/*
+Creates a name for the default ConfigMap with the PoolParty configuration properties.
+The properties will be provided as environment variables.
+*/}}
+{{- define "poolparty.fullname.configmap.properties" -}}
+  {{- printf "%s-%s" (include "poolparty.fullname" .) "properties" -}}
+{{- end -}}

--- a/poolparty/templates/config-properties.yaml
+++ b/poolparty/templates/config-properties.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.configuration.propertiesOverrides.existingConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "poolparty.fullname.configmap.properties" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $val := .Values.configuration.properties -}}
+    {{- if ne $val nil }}
+      {{- $key | nindent 2 }}: {{ tpl ($val | toString) $ | quote }}
+    {{- end }}
+  {{- end -}}
+{{ end }}

--- a/poolparty/templates/configmap-environment.yaml
+++ b/poolparty/templates/configmap-environment.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "poolparty.fullname.configmap.environment" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+data:
+  PP_JAVA_OPTS: >-
+    {{ tpl .Values.configuration.defaultJavaArguments . }}
+    {{ tpl .Values.configuration.javaArguments . }}

--- a/poolparty/templates/extra-objects.yaml
+++ b/poolparty/templates/extra-objects.yaml
@@ -1,0 +1,5 @@
+{{ range .Values.extraObjects }}
+---
+{{- $value := typeIs "string" . | ternary . (. | toYaml) }}
+{{ tpl $value $ }}
+{{ end }}

--- a/poolparty/templates/ingress.yaml
+++ b/poolparty/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled }}
+{{- $external_url := urlParse (include "poolparty.external-url" .) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "poolparty.fullname" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.ingress.annotations) }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if or .Values.ingress.tls.enabled .Values.ingress.extraTLS }}
+  tls:
+    {{- if .Values.ingress.tls.enabled }}
+    - hosts:
+        - {{ coalesce .Values.ingress.host $external_url.host }}
+      secretName: {{ required "TLS secret is required!" .Values.ingress.tls.secretName }}
+    {{- end }}
+    {{- with .Values.ingress.extraTLS }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ coalesce .Values.ingress.host $external_url.host }}
+      http:
+        paths:
+          - path: {{ coalesce .Values.ingress.path $external_url.path "/" }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "poolparty.fullname" . }}
+                port:
+                  number: {{ .Values.service.ports.http }}
+    {{- with .Values.ingress.extraHosts }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/poolparty/templates/service.yaml
+++ b/poolparty/templates/service.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "poolparty.fullname" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.service.annotations) }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "poolparty.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.healthCheckNodePort }}
+  healthCheckNodePort: {{ .Values.service.healthCheckNodePort }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{ .Values.service.externalIPs | toYaml | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      targetPort: http
+      protocol: TCP
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  {{- with .Values.service.extraPorts -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/poolparty/templates/serviceaccount.yaml
+++ b/poolparty/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "poolparty.serviceAccountName" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+  {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.serviceAccount.annotations) }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/poolparty/templates/statefulset.yaml
+++ b/poolparty/templates/statefulset.yaml
@@ -1,0 +1,208 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "poolparty.fullname" . }}
+  namespace: {{ include "poolparty.namespace" . }}
+  labels:
+    {{- include "poolparty.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  serviceName: {{ include "poolparty.fullname" . }}
+  updateStrategy: {{ .Values.updateStrategy | toYaml | nindent 4 }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  persistentVolumeClaimRetentionPolicy: {{ .Values.persistence.volumeClaimRetentionPolicy | toYaml | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "poolparty.selectorLabels" . | nindent 6 }}
+  {{- if or .Values.persistence.enabled .Values.extraVolumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- if .Values.persistence.enabled }}
+    - metadata:
+        name: {{ .Values.persistence.volumeClaimTemplate.name }}
+        {{- with .Values.persistence.volumeClaimTemplate.labels }}
+        labels: {{ tpl (toYaml .) $ | nindent 10 }}
+        {{- end }}
+        {{- with .Values.persistence.volumeClaimTemplate.annotations }}
+        annotations: {{ tpl (toYaml .) $ | nindent 10 }}
+        {{- end }}
+      spec:
+        {{- toYaml .Values.persistence.volumeClaimTemplate.spec | nindent 8 }}
+    {{- end }}
+    {{- with .Values.extraVolumeClaimTemplates }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "poolparty.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/configmap-environment: {{ include (print .Template.BasePath "/configmap-environment.yaml") . | sha256sum }}
+        {{- if not .Values.configuration.propertiesOverrides.existingConfigmap }}
+        checksum/config-properties: {{ include (print .Template.BasePath "/config-properties.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "poolparty.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      volumes:
+        {{- if not .Values.persistence.enabled }}
+        - name: {{ .Values.persistence.volumeClaimTemplate.name }}
+          emptyDir: {{ .Values.persistence.emptyDir | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.tempVolume.enabled }}
+        - name: temp-dir
+          emptyDir: {{ .Values.tempVolume.emptyDir | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.configuration.logback.existingConfigmap }}
+        - name: poolparty-logback-config
+          configMap:
+            name: {{ tpl .Values.configuration.logback.existingConfigmap . }}
+        {{- end }}
+        {{- if .Values.license.existingSecret }}
+        - name: poolparty-license
+          secret:
+            secretName: {{ tpl .Values.license.existingSecret . }}
+            optional: {{ .Values.license.optional }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.affinity .Values.podAntiAffinity.enabled }}
+      affinity:
+        {{- if .Values.affinity  }}
+          {{- tpl (toYaml .Values.affinity) $ | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.podAntiAffinity.enabled (not .Values.affinity.podAntiAffinity) }}
+        podAntiAffinity:
+          {{- if eq .Values.podAntiAffinity.preset "soft" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: {{ .Values.podAntiAffinity.topology }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "poolparty.selectorLabels" . | nindent 20 }}
+          {{- else if eq .Values.podAntiAffinity.preset "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.podAntiAffinity.topology }}
+              labelSelector:
+                matchLabels:
+                  {{- include "poolparty.selectorLabels" . | nindent 18 }}
+          {{- else }}
+            {{- fail (printf "Unknown podAntiAffinity preset '%s'" .Values.podAntiAffinity.preset) }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.global.imagePullSecrets .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- include "poolparty.combinedImagePullSecrets" . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- with .Values.extraInitContainers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "poolparty.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+            {{- with .Values.extraContainerPorts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.configuration.propertiesOverrides.existingConfigmap }}
+            - configMapRef:
+                name: {{ .Values.configuration.propertiesOverrides.existingConfigmap }}
+            {{- else }}
+            - configMapRef:
+                name: {{ include "poolparty.fullname.configmap.properties" . }}
+            {{- end }}
+            {{- if .Values.configuration.propertiesOverrides.existingSecret }}
+            - secretRef:
+                name: {{ .Values.configuration.extraProperties.existingSecret }}
+            {{- end }}
+            - configMapRef:
+                name: {{ include "poolparty.fullname.configmap.environment" . }}
+            {{- with .Values.extraEnvFrom }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ .Values.persistence.volumeClaimTemplate.name }}
+              mountPath: /var/lib/poolparty
+            - name: temp-dir
+              mountPath: /tmp
+            {{- if .Values.license.existingSecret }}
+            - name: poolparty-license
+              mountPath: /usr/share/poolparty/config/licenses
+              readOnly: {{ .Values.license.readOnly }}
+            {{- end }}
+            {{- if .Values.configuration.logback.existingConfigmap }}
+            - name: poolparty-logback-config
+              mountPath: /var/lib/poolparty/config/logback.xml
+              subPath: {{ .Values.configuration.logback.configmapKey }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with .Values.extraContainers }}
+          {{ tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}

--- a/poolparty/values.yaml
+++ b/poolparty/values.yaml
@@ -1,0 +1,656 @@
+###############################################################################
+#                        Main configuration file                              #
+#                                                                             #
+# To override single property use --set                                       #
+# To override multiple, provide another values-override.yaml with the -f flag #
+# See https://helm.sh/docs/chart_template_guide/values_files/                 #
+###############################################################################
+
+#########################
+# Global Configurations #
+#########################
+
+global:
+  # Overrides image.registry
+  # Can be used to override it globally when using umbrella charts.
+  imageRegistry: ""
+
+  # Inserts additional pull secret references along with any from .Values.image.pullSecrets
+  # Can be used to override it globally when using umbrella charts.
+  # Values are processed as Helm templates.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/secret/#using-imagepullsecrets
+  #
+  # Example:
+  # imagePullSecrets:
+  #   - name: my-pull-secret
+  imagePullSecrets: []
+
+  # The default domain suffix of the Kubernetes cluster
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+  clusterDomain: cluster.local
+
+###############################
+#   Metadata Configurations   #
+# Naming and labels overrides #
+###############################
+
+# Overrides the name of the chart affecting the names of PoolParty resources.
+nameOverride: ""
+
+# Overrides the naming of all PoolParty resources, effectively removing the chart's name and the release name prefix.
+# This override takes precedence over anything in .Values.nameOverride
+fullnameOverride: ""
+
+# Overrides the deployment namespace in case of multi-namespace deployments, for example when using umbrella charts
+# where some sub-charts should be deployed in different namespaces.
+# This affects every resource deployed by this chart.
+# The default value is .Release.Namespace if this is left unspecified.
+namespaceOverride: ""
+
+# Additional common labels to add to all resources of PoolParty.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+#
+# Example:
+# labels:
+#   foo: bar
+#   some-label: {{ .Values.someValue }}
+labels: {}
+
+# Additional common annotations to add to all resources of PoolParty.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+#
+# Example:
+# annotations:
+#   foo: bar
+#   some-annotation: {{ .Values.someValue }}
+annotations: {}
+
+##################################
+# PoolParty Image Configurations #
+##################################
+
+# Image configurations for PoolParty.
+# All containers in this chart use the PoolParty image, all init containers and any Jobs as well.
+# Ref: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  # The registry that hosts the PoolParty image.
+  # The default is to pull it from the official Docker registry, but this can be overridden to pull from other public or
+  # private registries.
+  registry: docker.io
+
+  # The repository name of the PoolParty image.
+  repository: ontotext/poolparty
+
+  # Image tag that corresponds to the version of PoolParty.
+  # By default, the chart uses .Chart.AppVersion to construct the full image name.
+  # Use this to override the value from .Chart.AppVersion and effectively deploy a custom PoolParty version.
+  tag: ""
+
+  # Expected SHA256 digest of the used PoolParty image, e.g. "sha256@abc"
+  # Use the digest to make sure you are always deploying the exact same PoolParty image.
+  # Defining this would override .Chart.AppVersion and image.tag
+  digest: ""
+
+  # Defines the policy for pulling images
+  # Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+  pullPolicy: IfNotPresent
+
+  # Secrets for pulling PoolParty's Docker image from secured registries.
+  # Values are processed as Helm templates.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/secret/#using-imagepullsecrets
+  #
+  # Example:
+  # pullSecrets:
+  #   - name: my-pull-secret
+  pullSecrets: []
+
+############################
+# PoolParty Configurations #
+############################
+
+# Commercial license is required for using PoolParty.
+license:
+  # Reference to a secret containing 'poolparty.key' file that will be mounted in the PoolParty pod.
+  # The value is processed as a Helm template.
+  existingSecret: ""
+
+  # Name of the PoolParty license file in the existing license secret.
+  # The default is poolparty.key, but it can be changed to map to a different secret key.
+  licenseFilename: poolparty.key
+
+  # Defines the secret volume as optional or not.
+  # Note: Useful if the PoolParty license has not yet been provisioned but will be, for example by an external system or
+  # an operator such as External Secret Operator.
+  optional: false
+
+  # Marks the secret mount as read-only to prevent any modifications to the license file.
+  readOnly: true
+
+# PoolParty runtime configuration settings.
+# Ref. TODO
+configuration:
+  # The external URL at which PoolParty should be accessible.
+  # This can be a publicly available domain name, an internal one or even a Kubernetes service address.
+  #
+  # This configures the address resolving in PoolParty, if enabled.
+  # It also configures the hostname in the default Ingress resource, if enabled.
+  # The value is processed as a Helm template.
+  #
+  # Note: If the external URL uses HTTPS and the default Ingress is enabled, you have to configure .Values.ingress.tls
+  #
+  # Note: When deploying on a context path different from /, you need to properly configure the Ingress according to the
+  # requirements of the Ingress controller implementation.
+  externalUrl: http://poolparty.127.0.0.1.nip.io
+
+  # Additional PoolParty configurations that will be appended to poolparty.properties, effectively overriding anything
+  # configured in the default poolparty.properties ConfigMap.
+  # The ConfigMap serves as source for environment variables passed to the PoolParty.
+  # Values are processed as Helm templates.
+  #
+  # Example:
+  # properties:
+  #   POOLPARTY_GRAPHDB_URL: "http://graphdb-node-0:7200, http://graphdb-node-1:7200"
+  properties:
+    ##### Encryption Settings #####
+    _POOLPARTY_ENCRYPTION_PASSWORD: 6wFdqOjvxuyeDvh1ENTm
+
+    ##### GraphDB Settings #####
+    POOLPARTY_GRAPHDB_URL: "http://graphdb:7200"
+    POOLPARTY_GRAPHDB_USERNAME: admin
+    POOLPARTY_GRAPHDB_PASSWORD: root
+
+    ##### Keycloak Settings #####
+    POOLPARTY_KEYCLOAK_AUTHURL: http://keycloak:8080/auth
+
+    POOLPARTY_KEYCLOAK_ADMIN_REALM: master
+    POOLPARTY_KEYCLOAK_ADMIN_USERNAME: poolparty_auth_admin
+    POOLPARTY_KEYCLOAK_ADMIN_PASSWORD: admin
+    POOLPARTY_KEYCLOAK_ADMIN_CLIENTID: admin-cli
+    POOLPARTY_KEYCLOAK_ADMIN_CLIENTSECRET: nPFFgUeLbmzjd28IObJEkkMtvd4TzvdF
+
+    POOLPARTY_KEYCLOAK_LOGIN_REALM: poolparty
+    POOLPARTY_KEYCLOAK_LOGIN_CLIENTID: ppt
+    POOLPARTY_KEYCLOAK_LOGIN_CLIENTSECRET: yaOd67b2HdQ28hmvuWvZMpn3TLrmhZ1u
+    POOLPARTY_KEYCLOAK_LOGIN_PRINCIPALATTRIBUTE: preferred_username
+    POOLPARTY_KEYCLOAK_LOGIN_ENABLEBASICAUTH: true
+
+    ##### Index Settings #####
+    POOLPARTY_INDEX_TYPE: elasticsearch
+    POOLPARTY_INDEX_URL: http://elasticsearch:9200
+
+  # PoolParty configurations settings to use instead of the ones defined into the default poolparty.properties ConfigMap.
+  #
+  # Example:
+  # propertiesOverrides:
+  #   existingConfigmap: my-poolparty-properties
+  #   existingSecret: my-secret-poolparty-properties
+  propertiesOverrides:
+    # Reference to an existing ConfigMap resource containing PoolParty configuration settings.
+    # Note: When providing override of the default ConfigMap, you need to provide all of the required properties!
+    # The value is processed as a Helm template.
+    existingConfigmap: ""
+
+    # Reference to an existing Secret resource containing sensitive PoolParty configuration settings.
+    # Note: The recommended way to provide all password and sensitive configurations.
+    # The value is processed as a Helm template.
+    existingSecret: ""
+
+  # Default Java arguments with which PoolParty instances will be launched.
+  # PoolParty configuration properties can also be passed here in the format -Dproperty=value
+  # The value is processed as a Helm template.
+  # Ref: TODO is there a documentation about specific Java Arguments for optimization of PP
+  defaultJavaArguments: -XX:MaxRAMPercentage=85
+
+  # Java arguments to append after .Values.configuration.defaultJavaArguments
+  # Use this one in order to avoid overriding the default values.
+  # The value is processed as a Helm template.
+  javaArguments: ""
+
+  # Configurations for PoolParty's Logback
+  # Ref: TODO
+  #
+  # Example:
+  # logback:
+  #   existingConfigmap: custom-logback-config
+  logback:
+    # Reference to an existing ConfigMap containing a Logback XML configuration.
+    # The value is processed as a Helm template.
+    existingConfigmap: ""
+
+    # Key in the existing ConfigMap that maps to the Logback XML configuration.
+    configmapKey: logback.xml
+
+##########################
+# Ingress Configurations #
+##########################
+
+# Configurations for the default Ingress resource for PoolParty.
+#
+# The default Ingress in this chart makes no assumptions of what Ingress controller is being used, it's up to you to
+# define any specific annotations required by the controller implementation in your cluster.
+#
+# Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  # Toggles the deployment of the default Ingress resource.
+  enabled: true
+
+  # Specifies the ingress controller implementation that will control this Ingress resource.
+  # Not defining this would result in using the default ingress controller in the cluster, if there is one.
+  className: ""
+
+  # Additional labels to append to the Ingress resource.
+  # Values are processed as Helm templates.
+  labels: {}
+
+  # Additional annotations to append to the Ingress resource.
+  # Values are processed as Helm templates.
+  annotations: {}
+
+  # If set, overrides the host from .Values.configuration.externalUrl
+  host: ""
+
+  # If set, overrides the context path from .Values.configuration.externalUrl
+  path: ""
+
+  # Sets the ingress path type.
+  # If you need to use ImplementationSpecific, make sure to set any annotations needed by the controller implementation.
+  pathType: Prefix
+
+  # Configures SSL termination on Ingress level.
+  # Ref: https://kubernetes.github.io/ingress-nginx/examples/tls-termination/
+  tls:
+    # Feature toggle for SSL termination. Disabled by default.
+    # If TLS is enabled, the .Values.configuration.externalUrl should also be updated to use HTTPS.
+    enabled: false
+
+    # Name of a Kubernetes Secret object with the key and certificate.
+    # If TLS is enabled, it's required to be provided, depending on the deployment.
+    # This could be an existing Secret or one that is not yet created.
+    secretName: ""
+
+  # List of additional hostnames to append to the Ingress resource.
+  # Values are processed as Helm templates.
+  extraHosts: []
+
+  # List of additional TLS records to append to the Ingress resource.
+  # Values are processed as Helm templates.
+  extraTLS: []
+
+##########################
+# Service Configurations #
+##########################
+
+# Configurations for PoolParty Service.
+# Ref: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # Enables or disables the Service deployment
+  enabled: true
+
+  # Additional labels to append to the Service resource.
+  # Values are processed as Helm templates.
+  labels: {}
+
+  # Additional annotations to append to the Service resource.
+  # Values are processed as Helm templates.
+  annotations: {}
+
+  # Service type
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+
+  # Ports exposed by the Service.
+  # Note: If you want to add additional ports, use .Values.service.extraPorts.
+  ports:
+    # Port mapped to PoolParty's HTTP API.
+    http: 8081
+
+  # Exposes the Service on a specific node port on the host machine when "serviceType: NodePort"
+  # If left undefined, K8S will pick a random port from the node port range of the cluster.
+  nodePort: ""
+
+  # Defines the policy for treating external ingress traffic.
+  # By default, Cluster does not preserve client IPs. Change to Local to preserve them.
+  # See https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  externalTrafficPolicy: ""
+
+  # NodePort used by external load balancers when the external traffic policy is set to Local.
+  # By default, Kubernetes will assign a random port, use this to override it.
+  healthCheckNodePort: ""
+
+  # Defines the class that should select a particular load balancer implementation.
+  # By default Kubernetes will assign the cluster default implementation, use this to override it.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+  loadBalancerClass: ""
+
+  # Source IP ranges for restricting external ingress traffic.
+  loadBalancerSourceRanges: []
+
+  # External IP addresses at which the Service will be exposed.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  externalIPs: []
+
+  # Additional ports to expose with the Service.
+  extraPorts: []
+
+##############################
+# Persistence Configurations #
+##############################
+
+persistence:
+  # Toggles the persistence of PoolParty data.
+  # - If enabled, the StatefulSet will use a PVC template and rely on the CSI to dynamically provision Persistent Volumes.
+  # - If disabled, it falls back to an emptyDir volume.
+  enabled: true
+
+  # Configurations for PVC based persistence.
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates
+  # Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  volumeClaimTemplate:
+    # Prefix used when naming the PVCs for the StatefulSet.
+    name: "storage"
+
+    # Additional labels to add to the PVC template.
+    # Values are processed as Helm templates.
+    labels: {}
+
+    # Additional annotations to add to the PVC template.
+    # Values are processed as Helm templates.
+    annotations: {}
+
+    # Specification for a PVC to be created by the StatefulSet.
+    # Tune according to your needs.
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi
+
+  # Overrides the retention policy of the StatefulSet's PVC.
+  # This requires Kubernetes v1.27 or greater.
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  #
+  # Example:
+  # volumeClaimRetentionPolicy:
+  #   whenScaled: Retain
+  #   whenDeleted: Delete
+  volumeClaimRetentionPolicy: {}
+
+  # Configurations for an emptyDir volume to be used for data storage by the StatefulSet.
+  # Used when the persistence is disabled with .Values.persistence.enabled
+  # Ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/
+  emptyDir:
+    # Default emptyDir limit, override to your needs.
+    sizeLimit: 1Gi
+
+# Configurations for an emptyDir volume for the /tmp folder in each PoolParty container.
+# Because the default security context in .Values.securityContext configures the root filesystem to be in read-only
+# mode, certain PoolParty features cannot create and write files in /tmp. If you don't use a read-only root filesystem,
+# you can disable this with .Values.tempVolume.enabled
+tempVolume:
+  # Toggles the temp folder emptyDir volume creation.
+  # - If enabled, the StatefulSet will use an emptyDir volume for /tmp.
+  # - If disabled, the chart won't create and mount ephemeral volumes for /tmp.
+  enabled: true
+
+  # Configurations for an emptyDir volume to be used for /tmp.
+  # Ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/
+  emptyDir:
+    # Default emptyDir limit, override to your needs.
+    sizeLimit: 128Mi
+
+##############################
+# StatefulSet Configurations #
+##############################
+
+# Configures the strategy of updating StatefulSet Pods.
+# The default type of RollingUpdate ensures that there will always be .Values.replicas amount of running nodes at the same time.
+# Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+updateStrategy:
+  type: RollingUpdate
+
+# Configures how Pods are created and scaled.
+# Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+podManagementPolicy: Parallel
+
+# Changes the maximum amount of revisions that are kept.
+revisionHistoryLimit: 10
+
+# Grace period in seconds before terminating the Pods.
+# Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+terminationGracePeriodSeconds: 120
+
+# Toggles the auto mounting of API credentials token into the Pods.
+# Enable this if you need to contact either the API server or need web identity credentials for federated authentication in cloud APIs.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+automountServiceAccountToken: false
+
+# Overrides the default Kubernetes scheduler.
+# See https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#specify-schedulers-for-pods
+schedulerName: ""
+
+# Overrides the Pod's DNS settings.
+# Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+dnsConfig: {}
+
+# Defines the Pod's policy for DNS resolution.
+# Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: ""
+
+# Name of an existing PriorityClass to assign, defining the importance of the pods compared to other pods in the cluster.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+priorityClassName: ""
+
+# Overrides the default PoolParty container command.
+# Use only for troubleshooting!
+# See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+command: []
+
+# Overrides the default PoolParty container command's arguments.
+# Use only for troubleshooting!
+# See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+args: []
+
+# Ports used by the PoolParty container
+# Note: If you want to add additional ports, use .Values.extraContainerPorts.
+containerPorts:
+  # Port mapped to PoolParty's HTTP API.
+  http: 8081
+
+# Additional labels to append to the Pod definition.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# Additional annotations to append to the Pod definition.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
+###################################
+# Security Context Configurations #
+###################################
+
+# Defines privilege and access control settings for all containers in the PoolParty Pod.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+# Defines privilege and access control settings for the container running PoolParty.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ "ALL" ]
+  seccompProfile:
+    type: RuntimeDefault
+
+# Defines privilege and access control settings for the init containers provisioning configurations for PoolParty.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+initContainerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ "ALL" ]
+  seccompProfile:
+    type: RuntimeDefault
+
+#############################
+# Scheduling Configurations #
+#############################
+
+# Selector labels to match when selecting nodes.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+# See https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+nodeSelector: {}
+
+# Node and pod affinity & anti affinity configurations for constraining the Pod scheduling.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# Default podAntiAffinity rule ensuring that PoolParty pods are scheduled on different Kubernetes nodes.
+# Note that this would take effect when PoolParty is deployed in a cluster.
+#
+# Possible values for .Values.podAntiAffinity.preset are:
+# - "soft" (default) - Configures a preferredDuringSchedulingIgnoredDuringExecution rule.
+# - "hard" - Configures a requiredDuringSchedulingIgnoredDuringExecution rule.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+podAntiAffinity:
+  enabled: true
+  preset: soft
+  topology: kubernetes.io/hostname
+
+# List of taint tolerations.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+tolerations: []
+
+# Configurations for spreading Pods across different failure domains.
+# Values are processed as Helm templates.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#pod-topology-spread-constraints
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+
+##########################
+# Resource Configuration #
+##########################
+
+# Resource configurations for the PoolParty containers.
+# For resizing to your needs, refer to the PoolParty documentation TODO
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+
+# TODO
+resources:
+  limits:
+    memory: 8Gi
+  requests:
+    memory: 8Gi
+    cpu: 500m
+
+#########################
+# Probes Configurations #
+#########################
+
+# Configurations for the PoolParty container startup probe.
+startupProbe:
+  httpGet:
+    path: /PoolParty/health/startup
+    port: http
+  failureThreshold: 300
+  timeoutSeconds: 1
+  periodSeconds: 3
+
+# Configurations for the PoolParty container readiness probe.
+readinessProbe:
+  httpGet:
+    path: /PoolParty/health/readiness
+    port: http
+  timeoutSeconds: 5
+  periodSeconds: 10
+
+# Configurations for the PoolParty container liveness probe.
+livenessProbe:
+  httpGet:
+    path: /PoolParty/health/liveness
+    port: http
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  periodSeconds: 10
+
+#########################################
+# Additional StatefulSet Configurations #
+#########################################
+
+# Additional environment variables to be set for the PoolParty containers.
+# Values are processed as Helm templates.
+extraEnvFrom: []
+
+# Additional environment variables to be set for the PoolParty containers.
+# Values are processed as Helm templates.
+extraEnv: []
+
+# Additional volumes to be set for the PoolParty Pod.
+# Values are processed as Helm templates.
+extraVolumes: []
+
+# Additional volume mounts to be set for the PoolParty containers.
+# Values are processed as Helm templates.
+extraVolumeMounts: []
+
+# Additional volume claim templates to be set in PoolParty's StatefulSet.
+# Values are processed as Helm templates.
+extraVolumeClaimTemplates: []
+
+# Additional init containers to be inserted after the provisioning init containers.
+# Values are processed as Helm templates.
+extraInitContainers: []
+
+# Additional PoolParty container ports to expose.
+extraContainerPorts: {}
+
+# Additional containers to insert into the PoolParty Pod, e.g. sidecar containers
+# Values are processed as Helm templates.
+extraContainers: []
+
+##################################
+# Service Account Configurations #
+##################################
+
+# Configurations for the default ServiceAccount for PoolParty.
+# PoolParty by itself has no need to communicate with the Kubernetes API but the service account tokens can be used
+# as ODIC federated web identity tokens for authentication in cloud APIs.
+# Ref: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created for PoolParty.
+  create: false
+
+  # The name of the ServiceAccount to use.
+  #
+  # There are three cases to be aware of when using this:
+  # - If not set and create is true, a name is generated using the fullname template
+  # - If set and create is true, it will use the provided name when creating the ServiceAccount
+  # - If set but create is false, it will use the provided ServiceAccount.
+  name: ""
+
+  # If .Values.serviceAccount.create is true, insert additional annotations to the created ServiceAccount.
+  # Values are processed as Helm templates.
+  annotations: {}
+
+#################################
+# Additional Kubernetes Objects #
+#################################
+
+# Additional objects to insert along with the release.
+# Values are processed as Helm templates with tpl function.
+# Ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+extraObjects: []


### PR DESCRIPTION
- Added Helm Chart definition and deployment resources for the PoolParty application.

  The chart will be used as part of the Graphwise Platform umbrella chart which will reside in the same repository at the moment. It will combine other components, which are essential for the PoolParty application, like Elasticsearch, Keycloak, GraphDB, etc.

  The first version that the chart will support is **PoolParty 10.0**.

Related tasks: [GWP-698](https://graphwise.atlassian.net/browse/GWP-698)

[GWP-698]: https://graphwise.atlassian.net/browse/GWP-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ