### PR TITLE
Fixes the resources section for the PoolParty

### DIFF
--- a/adf/values.yaml
+++ b/adf/values.yaml
@@ -487,9 +487,9 @@ topologySpreadConstraints: []
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
 
 resources:
-  limits:
-    memory: 2Gi
   requests:
+    memory: 2Gi
+  limits:
     memory: 2Gi
 
 #########################

--- a/poolparty/CHANGELOG.md
+++ b/poolparty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PoolParty Helm Chart Changelog
 
+## Version 0.2.2
+
+- Fixes the `resources` section in the chart. We've switched the values for `request` and `limit`.
+
 ## Version 0.2.1
 
 - Updates the version of the PoolParty to `10.1.1`.

--- a/poolparty/Chart.yaml
+++ b/poolparty/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PoolParty is a semantic middleware, it tackles the ever-growing problems associated with unstructured data, language
   ambiguity, and data silos.
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 10.1.1
 kubeVersion: ^1.32.0-0
 home: https://www.poolparty.biz/

--- a/poolparty/values.yaml
+++ b/poolparty/values.yaml
@@ -578,11 +578,11 @@ topologySpreadConstraints: []
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
 
 resources:
-  limits:
-    memory: 8Gi
   requests:
-    memory: 12Gi
+    memory: 8Gi
     cpu: 500m
+  limits:
+    memory: 12Gi
 
 #########################
 # Probes Configurations #

--- a/workbench/values.yaml
+++ b/workbench/values.yaml
@@ -538,11 +538,11 @@ topologySpreadConstraints: []
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
 
 resources:
-  limits:
-    memory: 5Gi
   requests:
     memory: 4Gi
     cpu: 500m
+  limits:
+    memory: 5Gi
 
 #########################
 # Probes Configurations #


### PR DESCRIPTION
- The previous values for the `resources.request` and `resources.limit` were switch, which may cause unexpected behavior or application shutdown in specific cases.

  The version of the chart was bumped in order to have new patch
release.

- Unified the `resources` section structure for all applications so that we can avoid errors.

  There is no need to release other charts at the moment, because only the places of the `request` and `limit` were moved, the values remain the same.