### PR TITLE
Bumps the version of the Semantic Workbench application and chart

### DIFF
--- a/workbench/CHANGELOG.md
+++ b/workbench/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Semantic Workbench Helm Chart Changelog
 
+## Version 0.1.3
+
+- Bumped the version of the Semantic Workbench application to `2.4.2`.
+
 ## Version 0.1.2
 
 - Bumped the version of the Semantic Workbench application to `2.4.1`.

--- a/workbench/Chart.yaml
+++ b/workbench/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   The Workbench supports subject matter experts in finding the optimal combination of parameters for inference tagging
   and semantic recommender features.
 type: application
-version: 0.1.2
-appVersion: 2.4.1
+version: 0.1.3
+appVersion: 2.4.2
 kubeVersion: ^1.32.0-0
 home: https://help.poolparty.biz/en/poolparty-quick-start-guides/poolparty-workbench-at-a-glance.html
 icon: https://www.poolparty.biz/wp-content/uploads/2017/04/pp_logo.svg

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,8 +1,8 @@
 # Helm Chart for Semantic Workbench
 
 [![CI - Pull Request](https://github.com/poolparty-semantic-suite/charts/actions/workflows/pull-request.yml/badge.svg)](https://github.com/poolparty-semantic-suite/charts/actions/workflows/pull-request.yml)
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
-![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
+![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 Welcome to the official [Helm](https://helm.sh/) chart repository for [Semantic Workbench](https://www.poolparty.biz/)!
 This Helm chart makes it easy to deploy and manage Semantic Workbench on your [Kubernetes](https://kubernetes.io/)
@@ -29,7 +29,7 @@ The table bellow highlights the version mapping between the Helm chart and Seman
 
 | Helm chart version | Semantic Workbench version  |
 |--------------------|-----------------------------|
-| 0.1.x              | 2.3.x                       |
+| 0.1.x              | 2.4.x                       |
 
 # Prerequisites
 

--- a/workbench/README.md.gotmpl
+++ b/workbench/README.md.gotmpl
@@ -29,7 +29,7 @@ The table bellow highlights the version mapping between the Helm chart and Seman
 
 | Helm chart version | Semantic Workbench version  |
 |--------------------|-----------------------------|
-| 0.1.x              | 2.3.x                       |
+| 0.1.x              | 2.4.x                       |
 
 # Prerequisites
 


### PR DESCRIPTION
- Updated the version of the Semantic Workbench application to latest `2.4.2`.

  The chart version is also bumped to `0.1.3`.

  The new version contains couple of minor fixes that don't require any specific actions.

- Added minor fixes to the documentation.