### PR TITLE
Updates the examples for Elasticsearch to use the latest version

### DIFF
--- a/poolparty/CHANGELOG.md
+++ b/poolparty/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PoolParty Helm Chart Changelog
 
+## Version XXX (Unreleased)
+
+- Updated the [examples/](examples) to use `ontotext/poolparty-elasticsearch:9.3.8`. The new version of Elasticsearch
+  contains security patches.
+
 ## Version 0.3.3
 
 - Updates Graph Modeler (PoolParty) to **10.2.2**. The version contains couple of important security patches and

--- a/poolparty/examples/dependencies/elasticsearch.yaml
+++ b/poolparty/examples/dependencies/elasticsearch.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: elasticsearch
-          image: ontotext/poolparty-elasticsearch:9.3.3
+          image: ontotext/poolparty-elasticsearch:9.3.8
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
- Recently we have released new Ealsticsearch image **9.3.8**, which contains fixes for security issues.

  The examples are now updated to use that version instead of the older one.